### PR TITLE
Change publish dir and build output to /dest

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -18,4 +18,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./dist
+          publish_dir: ./dest

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "eleventy --serve --input ./src --output ./dest",
-    "build": "eleventy --input ./src"
+    "build": "eleventy --input ./src --output ./dest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
I am hoping this fixes deploying the gh pages by ensuring that 11ty builds the files in the same directory that the `eleventy_build.yml` process expects.