### PR TITLE
Re-add favicon

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/assets/**/*");
+  eleventyConfig.addPassthroughCopy("src/favicon.png");
   eleventyConfig.setBrowserSyncConfig({
     callbacks: {
       ready: function(err, browserSync) {


### PR DESCRIPTION
11ty is picky about what files it will copy over to the destination directory. Tell 11ty to copy over favicon, and be done with it.