### PR TITLE
Add cname to deploy action

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./dest
+          cname: hoshudojo.com


### PR DESCRIPTION
The CNAME missing meant that whenever the deploy action was triggered, the cname was deleted, breaking the gh-page from working with the domain.