### PR TITLE
Add landing page for 2023 Jodo Seminar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-/dest
+**.DS_Store
+*.jekyll-cache
+/.idea/
 /_site
+/dest
 /legacy/_site
 /node_modules
-*.jekyll-cache
-**.DS_Store

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -10,12 +10,6 @@
       "props": ""
     },
     {
-      "description": "2023 Jodo Seminar",
-      "id": "2023jodoseminar",
-      "href": "/events/2023jodoseminar",
-      "props": ""
-    },
-    {
       "description": "Locations",
       "id": "locations",
       "href": "/locations",

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -10,6 +10,12 @@
       "props": ""
     },
     {
+      "description": "2023 Jodo Seminar",
+      "id": "2023jodoseminar",
+      "href": "/events/2023jodoseminar",
+      "props": ""
+    },
+    {
       "description": "Locations",
       "id": "locations",
       "href": "/locations",

--- a/src/_includes/hero.liquid
+++ b/src/_includes/hero.liquid
@@ -2,8 +2,8 @@
   <div class="c-splash-card">
     <aside class="c-splash-card__banner">
       <picture>
-        <source media="(min-width: 600px)" srcset="/assets/img//home-banner-desktop.jpg"/>
-        <img alt="Photograph of Thomas Groendal and Ben Lew facing off in a Jodo kata" class="c-splash-card__image" src="/assets/img//home-banner-mobile.jpg" width="320"/>
+        <source media="(min-width: 600px)" srcset="/assets/img/home-banner-desktop.jpg"/>
+        <img alt="Photograph of Thomas Groendal and Ben Lew facing off in a Jodo kata" class="c-splash-card__image" src="/assets/img/home-banner-mobile.jpg" width="320"/>
       </picture>
     </aside>
 

--- a/src/_includes/home.liquid
+++ b/src/_includes/home.liquid
@@ -53,7 +53,7 @@ layout: default
 
 <section class="t-home__locations">
   <div class="c-overlay-card">
-    <img alt="Photo of a classroom with students throughout" class="c-overlay-card__image" src="/assets/img//location-banner.jpg"/>
+    <img alt="Photo of a classroom with students throughout" class="c-overlay-card__image" src="/assets/img/location-banner.jpg"/>
 
     <div class="c-overlay-card__content">
       <div class="c-sheet">
@@ -77,7 +77,7 @@ layout: default
 
 <section class="t-home__instructor">
   <div class="c-overlay-card">
-    <img alt="Photo of Hoshu Dojo head instructor Goto Sensei performing kata" class="c-overlay-card__image" src="/assets/img//head-instructor-banner.jpg"/>
+    <img alt="Photo of Hoshu Dojo head instructor Goto Sensei performing kata" class="c-overlay-card__image" src="/assets/img/head-instructor-banner.jpg"/>
 
     <div class="c-overlay-card__content">
       <div class="c-sheet">

--- a/src/_includes/home.liquid
+++ b/src/_includes/home.liquid
@@ -22,6 +22,13 @@ layout: default
   </div>
 </nav>
 
+<section class="t-home__events">
+  <div class="c-sheet">
+    <p>{{ seminar.title }}</p>
+    <a class="c-button" href="/events/2023jodoseminar">{{ seminar.button }}</a>
+  </div>
+</section>
+
 <section class="t-home__about">
   <div class="c-sheet u-text-content">
     <h2 class="c-h2 u-weight--light">

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2648,16 +2648,19 @@ div.jGrowl div.jGrowl-closer {
   }
 }
 
-@media screen and (min-width: 600px) {
-  .t-home__events {
-      float:left;
-      width: 50%
-  }
+.t-home__events {
+  display: grid;
+  justify-content: center;
 }
 
-@media screen and (min-width: 900px) {
-  .t-home__events {
-      padding-left:5%
+.t-home__events p {
+  text-align: center;
+}
+
+@media screen and (min-width: 600px) {
+  .t-home__events .c-button {
+    width: 50%;
+    margin: auto;
   }
 }
 

--- a/src/events/2023jodoseminar.md
+++ b/src/events/2023jodoseminar.md
@@ -151,7 +151,7 @@ lang: "en"
     Center and Cherry Street Market. You are free to make your own arrangements to stay off-campus, but we encourage you to join
     the group!</p>
 
-  <p>A meal plan is included in the accommodation packages, and is also available even if you're not staying at Seattle
+  <p>A meal plan is included in the accommodation packages (required by Seattle University), and is also available even if you're not staying at Seattle
     University.</p>
 
   <ul class="list">
@@ -161,6 +161,7 @@ lang: "en"
     <li>Deluxe Double with meal plan, <b>$297</b> per person</li>
     <li>Meal plan but no accommodation, <b>$90</b> per person</li>
   </ul>
+
 
 <h3>About the accommodation</h3>
 
@@ -172,9 +173,9 @@ lang: "en"
     Single rooms available, so get in quick!</p>
 
   <p>All accommodation options are for 3 nights, checking in on Thursday and checking out on Sunday. You will need to check-in
-    when you arrive to collect your room key and information. Thursday check-in is between 1pm and 10pm; Sunday check-out is
-    any time before 10am, and Luggage storage is available for the remainder of the seminar on Sunday. More information on what to
-    expect when checking in and out will be provided closer to the date.</p>
+    when you arrive to collect your room key and information. Thursday check-in is between 1pm and 10pm; Sunday check-out is any
+    time before 10am. Luggage storage is available for the remainder of the seminar on Sunday, and if you arrive earlier than 1pm
+    on Thursday. More information on what to expect when checking in and out will be provided closer to the date.</p>
 
   <ul>
     <li><b>Chardin Hall</b>: <a href="https://goo.gl/maps/6gdJY84x5AWaDzUH9" target="_blank">1020 East Jefferson, Seattle, WA
@@ -188,8 +189,9 @@ lang: "en"
 
 <h3>About the meal plan</h3>
 
- <p>A meal plan is available to everyone attending the seminar, even if you're not staying at Seattle University. Meals will be
-  served at the Cherry Street Market at the Seattle University Student Center. The meal plan includes:</p>
+ <p>A meal plan is available to everyone attending the seminar, even if you're not staying at Seattle University. If you
+  <em>are</em> staying at Seattle University, it's included in your accommodation package (required by Seattle University). Meals
+  will be served at the Cherry Street Market at the Seattle University Student Center. The meal plan includes:</p>
 
   <ul class="list">
     <li>Friday breakfast, lunch, and dinner</li>

--- a/src/events/2023jodoseminar.md
+++ b/src/events/2023jodoseminar.md
@@ -1,0 +1,256 @@
+---
+layout: page
+title: "2023 Jodo Seminar"
+permalink: "/events/2023jodoseminar/"
+lang: "en"
+---
+
+<style>
+  section:not(:first-of-type) {
+    margin-top: 3rem;
+  }
+  a.registration {
+    font-weight: bold;
+    font-size: larger;
+  }
+  @media screen and (min-width: 600px) {
+    a.registration {
+      width: 50%;
+      margin: auto;
+    }
+  }
+  .list, .schedule ol {
+    list-style: disc;
+    margin: 1.5rem 0 1.5rem 3rem;
+  }
+  .gmap {
+    display: block;
+    position: relative;
+    margin: 1rem auto;
+  }
+
+  @media screen and (max-width: 599px) {
+    .gmap {
+      width: 90% !important;
+    }
+  }
+
+  .schedule > li {
+    margin: 1rem 0;
+  }
+  .schedule span {
+    font-weight: bold;
+  }
+
+</style>
+
+<h1>2023 Jodo Seminar</h1>
+
+<section>
+  <h2>Welcome to registration for the 2023 Hoshu Dojo Jodo Camp!</h2>
+
+  <p>This year will be Goto-Sensei's 10th trip to the Americas, and to honour the special anniversary we will be doing a
+    gasshuku-style event - an all-inclusive camp where we train, stay, eat, and socialize together.</p>
+
+  <p>This year's camp will be held at Seattle University in Seattle, WA, from Thursday July 6th through Sunday July 9th, with
+    training across two and a half days from Friday through Sunday. Both room and board will also be provided by Seattle U,
+    with the exception of the "formal" camp dinner on Saturday night held at Olmstead Restaurant. There will be several options of
+    rooms available with differing price ranges. While staying at Seattle U is not required, it is highly encouraged. Food is
+    available at the university even if you are not staying there - but will need to be pre-registered.</p>
+
+  <p>Read on for more information about the camp, including the seminar schedule, accommodiation, meals, and parking.</p>
+
+  <p>We look forward to seeing you in July!</p>
+</section>
+
+<section>
+  <p><a class="c-button registration"
+        href="https://docs.google.com/forms/d/e/1FAIpQLScAEBHP5Z_UEyR4qcUPEaxPzPXljhoJwsyzIooRw4cVCvXNAg/viewform"
+        target="_blank"> Click
+    here to
+    register</a></p>
+
+  <p>Since this year's camp involves coordination with Seattle University, deadlines for registration and payment are
+    <b>Sunday April 30th</b> for Early Bird pricing, and <b>Friday June 9th</b> for regular pricing.</p>
+
+  <p>We will reach out to you via email after you have submitted your registration to confirm everything, sign a waiver, provide
+    payment totals and instructions, and let you know what to expect when you arrive. Please reach out to us at <a
+    href="mailto:seminar2023@hoshudojo.com" target="_blank">seminar2023@hoshudojo.com</a> if you have any questions, if
+    you anticipate you cannot make the deadlines, or if the provided options don't work for you.</p>
+
+</section>
+
+<section>
+  <h2>Full Schedule</h2>
+
+  <ol class="schedule">
+    <li>
+      <span>Thursday, July 6th</span>
+      <ol>
+        <li>1 pm to 10 pm: Accommodation Check-in</li>
+      </ol>
+    </li>
+    <li>
+      <span>Friday, July 7th</span>
+      <ol>
+        <li>TBD: Breakfast</li>
+        <li>9 am to 12 noon: Morning Seminar</li>
+        <li>12 noon to 1 pm: Lunch</li>
+        <li>1 pm to 5 pm: Afternoon Seminar</li>
+        <li>TBD: Dinner</li>
+      </ol>
+    </li>
+    <li>
+      <span>Saturday, July 8th</span>
+      <ol>
+        <li>TBD: Breakfast</li>
+        <li>9 am to 12 noon: Morning Seminar</li>
+        <li>12 noon to 1 pm: Lunch</li>
+        <li>1 pm to 5 pm: Afternoon Seminar</li>
+        <li>TBD (likely 6:30 or 7 pm): Camp Dinner at Olmstead</li>
+      </ol>
+    </li>
+    <li>
+      <span>Sunday, July 9th</span>
+      <ol>
+        <li>TBD: Breakfast</li>
+        <li>Before 10 am: Check-out</li>
+        <li>9 am to 12 noon: Morning Seminar</li>
+      </ol>
+    </li>
+  </ol>
+
+  <p>The exact times may change as we get closer to the event. We will send updates when things change, but please check here
+    for updates!</p>
+</section>
+
+<section>
+  <h2>Seminar</h2>
+
+  <p>The seminar will be held in Seattle University's <b>Redhawk Center Fitness Room (Studio 1)</b>. The Seminar fee covers the
+    cost of the facility and contributes to airfare for Goto Sensei and Yuka. Costs for lodging, meal plans and parking are not
+    included - more on those below.</p>
+
+  <ul class="list">
+    <li><b>Early Bird</b> pricing for the seminar is $250 per person<br />
+      Registration and payment must be received on or before <b>Sunday April 30th</b> to be eligible.</li>
+    <li><b>Regular pricing</b> from May 1st is $300 per person</li>
+  </ul>
+
+  <p><b>Redhawk Center</b>: <a href="https://goo.gl/maps/cRx3md5mSbecGUcD7" target="_blank">550 14th Ave, Seattle, WA 98112</a>.
+    The Redhawk Center is also known as the William F. Eisiminger Fitness Center.</p>
+
+  <iframe class="gmap" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.9676822307533!2d-122.31579468360036!3d47.607318079184836!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906ac5df623887%3A0x73c2e01c0cdb6c47!2sRedhawk%20Center!5e0!3m2!1sen!2sus!4v1680636688119!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+
+</section>
+
+<section>
+  <h2>Accommodation and Meals</h2>
+
+  <p>Accommodation is available in Seattle University's Chardin Hall and Bellarmine Hall, each a short walk to the Redhawk
+    Center and Cherry Street Market. You are free to make your own arrangements to stay off-campus, but we encourage you to join
+    the group!</p>
+
+  <p>A meal plan is included in the accommodation packages, and is also available even if you're not staying at Seattle
+    University.</p>
+
+  <ul class="list">
+    <li>Standard Single with meal plan, <b>$287</b> per person</li>
+    <li>Standard Double with meal plan, <b>$228</b> per person</li>
+    <li>Deluxe Single with meal plan, <b>$369</b> per person</li>
+    <li>Deluxe Double with meal plan, <b>$297</b> per person</li>
+    <li>Meal plan but no accommodation, <b>$90</b> per person</li>
+  </ul>
+
+<h3>About the accommodation</h3>
+
+  <p>All units include sinks, mirrors, cabinets, desks, compact refrigerator/microwave, wardrobes, and Wi-Fi internet throughout the
+    campus buildings. All beds are single-person beds.</p>
+
+  <p>The "Deluxe" units are in Chardin Hall, and each unit comes with its own private bathroom. The "Standard" units are in
+    Bellarmine Hall, with each unit sharing common bathrooms with the other units on the same floor. There are only 10 Deluxe
+    Single rooms available, so get in quick!</p>
+
+  <p>All accommodation options are for 3 nights, checking in on Thursday and checking out on Sunday. You will need to check-in
+    when you arrive to collect your room key and information. Thursday check-in is between 1pm and 10pm; Sunday check-out is
+    any time before 10am, and Luggage storage is available for the remainder of the seminar on Sunday. More information on what to
+    expect when checking in and out will be provided closer to the date.</p>
+
+  <ul>
+    <li><b>Chardin Hall</b>: <a href="https://goo.gl/maps/6gdJY84x5AWaDzUH9" target="_blank">1020 East Jefferson, Seattle, WA
+      98122</a></li>
+    <li><b>Bellarmine Hall</b>: <a href="https://goo.gl/maps/Jhc4BMp6WULccv9X8" target="_blank">1111 East Columbia Street,
+      Seattle, WA 98122</a></li>
+  </ul>
+
+  <iframe class="gmap" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.9951028153646!2d-122.31859469999999!3d47.6067849!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906ac7d0f0c9cb%3A0x45ab2858bb9bbbc1!2sChardin%20Hall%2C%201020%20E%20Jefferson%20St%2C%20Seattle%2C%20WA%2098122!5e0!3m2!1sen!2sus!4v1680639151793!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+  <iframe class="gmap" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.8956802067846!2d-122.31737109999999!3d47.6087181!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906ac8c8aac53b%3A0x4f98229b7e69c647!2sBellarmine%20Hall!5e0!3m2!1sen!2sus!4v1680639172220!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+
+<h3>About the meal plan</h3>
+
+ <p>A meal plan is available to everyone attending the seminar, even if you're not staying at Seattle University. Meals will be
+  served at the Cherry Street Market at the Seattle University Student Center. The meal plan includes:</p>
+
+  <ul class="list">
+    <li>Friday breakfast, lunch, and dinner</li>
+    <li>Saturday breakfast, and lunch</li>
+    <li>Sunday breakfast</li>
+  </ul>
+
+  <p>More info on the meals will be provided closer to the date. Vegan options are also available - please let us know in the
+    "Dietary and Special Accommodations" section of the registration form.</p>
+
+  <p>There is also a group dinner planned for Saturday night at the nearby restaurant <a href="https://goo.gl/maps/8WRPVSKkhdfUpBV3A" target="_blank">Olmstead</a>. Attendees will pay for their own meal and drinks directly to the restaurant on the night.</p>
+
+  <ul>
+    <li><b>Cherry Street Market</b>: <a href="https://goo.gl/maps/C6X1r57GbfFWxjRN8" target="_blank">Su Campus Walk, Seattle, WA
+      98122</a></li>
+    <li><b>Olmstead</b>: <a href="https://goo.gl/maps/pfkvBMgzHCBB5dfi7" target="_blank">314 Broadway E, Seattle, WA
+      98102</a></li>
+  </ul>
+
+  <iframe class="gmap" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10759.674471310844!2d-122.3183187!3d47.6082721!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54906ac891ab9599%3A0x1ed911c8f3e21013!2sCherry%20Street%20Market%20-%20Seattle%20University!5e0!3m2!1sen!2sus!4v1680639375963!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+  <iframe class="gmap" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.2350222196287!2d-122.3206264!3d47.62156259999999!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5490153b7de58cf1%3A0x83445694c63803ef!2sOlmstead!5e0!3m2!1sen!2sus!4v1680641487123!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+</section>
+
+<section>
+  <h2>Parking</h2>
+
+  <p>Parking is available through Seattle University. You can register now for a discounted price, or pay a higher fee if you
+    decide when you arrive. The standard rate for parking is $18 per calendar day if you don't pre-pay. Either way, we do not need
+    your car's registration information until you arrive.</p>
+
+  <p>Street parking in the area is very limited. We strongly recommend parking with Seattle University if you are driving.</p>
+
+  <p>We'll send more information closer to the date about parking with Seattle University - pre-paid or not.</p>
+
+</section>
+
+<section>
+  <h2>Dietary and Special Accommodations</h2>
+
+  <p>Please let us know in the "Dietary and Special Accommodations" section of the registration form if you require any
+    special accommodation fully participate in the seminar. Hoshu Dojo is responsible for notifying the University of any requests
+    by seminar participants with disabilities for reasonable accommodation that would require modification of University
+    facilities. Such notification must be made sufficiently in advance of the seminar for the University to consider the request,
+    determine whether the requested modification constitutes a reasonable accommodation or creates an undue hardship, and enter a
+    dialogue regarding the requested accommodation, if necessary. The University is not responsible for making the content of the
+    seminar accessible to persons with disabilities, such as providing interpreters for the deaf or assistance to the
+    vision-impaired.</p>
+
+  <p>Please also note that Seattle University dining hall kitchens and the venue for Saturday night's dinner are not kosher or
+    gluten free. Seattle University does have a station that avoids gluten but the kitchen still works with gluten in other areas.
+    This may be okay for people avoiding gluten for dietary or philosophical reasons, but might cause problem for people with
+    Celiac disease.</p>
+
+  <p>Please let us know in the "Dietary and Special Accommodations" section of the registration form if any of this affects you so
+    we can discuss arrangements.</p>
+
+</section>
+
+<section>
+  <h2>Seattle University is a non-smoking campus</h2>
+
+  <p>Smoking, vaping, and tobacco in any form are strictly prohibited everywhere on campus. Please find a public street off-campus
+    to smoke, vape, chew tobacco, etc.</p>
+</section>

--- a/src/events/2023jodoseminar.md
+++ b/src/events/2023jodoseminar.md
@@ -67,11 +67,20 @@ lang: "en"
   <p><a class="c-button registration"
         href="https://docs.google.com/forms/d/e/1FAIpQLScAEBHP5Z_UEyR4qcUPEaxPzPXljhoJwsyzIooRw4cVCvXNAg/viewform"
         target="_blank"> Click
-    here to
-    register</a></p>
+    here to register</a></p>
 
-  <p>Since this year's camp involves coordination with Seattle University, deadlines for registration and payment are
-    <b>Sunday April 30th</b> for Early Bird pricing, and <b>Friday June 9th</b> for regular pricing.</p>
+  <p>Deadlines for registration are</p>
+  <ol class="list">
+    <li><b>Sunday April 30th</b> for Early Bird pricing</li>
+    <li><b>Friday June 9th</b> for regular pricing</li>
+  </ol>
+
+  <p>The total due will be calculated from your choices for</p>
+  <ol class="list">
+    <li>The seminar fee</li>
+    <li>Accommodation and Meal plan</li>
+    <li>Parking</li>
+  </ol>
 
   <p>We will reach out to you via email after you have submitted your registration to confirm everything, sign a waiver, provide
     payment totals and instructions, and let you know what to expect when you arrive. Please reach out to us at <a
@@ -255,4 +264,10 @@ lang: "en"
 
   <p>Smoking, vaping, and tobacco in any form are strictly prohibited everywhere on campus. Please find a public street off-campus
     to smoke, vape, chew tobacco, etc.</p>
+</section>
+<section>
+  <p><a class="c-button registration"
+        href="https://docs.google.com/forms/d/e/1FAIpQLScAEBHP5Z_UEyR4qcUPEaxPzPXljhoJwsyzIooRw4cVCvXNAg/viewform"
+        target="_blank"> Click
+    here to register</a></p>
 </section>

--- a/src/index.md
+++ b/src/index.md
@@ -12,6 +12,9 @@ daitoryu:
   title: "Daito Ryu Aikijujutsu"
   part1: "Daito Ryu Aikijujutsu is the original “Aiki” art, an art of traditional Japanese jujutsu."
   part2: "This art includes sophisticated throws, joint locks and strikes, offering a rich reserve of technical knowledge."
+seminar:
+  title: "Registration for the 2023 Jodo Seminar is now open!"
+  button: "See More Details"
 locations:
   title: "Locations"
   list:


### PR DESCRIPTION
Adds a landing page for the 2023 Jodo Seminar.

- Creates new page at `/events/2023jodoseminar/`
- Adds banner near top of home page linking to landing page
- Repurposes unused `.t-home__events` class
- Landing page is deliberately _not_ included in the nav: it increases the size of the nav which overflows on smaller displays (eg: 390px for iPhone 12 Pro).